### PR TITLE
Changes for BL 7 Upgrade

### DIFF
--- a/blacklight_cql.gemspec
+++ b/blacklight_cql.gemspec
@@ -12,21 +12,20 @@ Gem::Specification.new do |s|
 
   s.rubyforge_project = "blacklight"
 
-  s.files = Dir["lib/**/*", "app/**/*", "config/**/*", "VERSION"]    
+  s.files = Dir["lib/**/*", "app/**/*", "config/**/*", "VERSION"]
   s.test_files    = Dir["app_root/**/*", "spec/**/*"]
-  
+
   s.require_paths = ["lib"]
 
   s.add_dependency "rails"
-  s.add_dependency "blacklight", ">= 5.14.0", "< 7.0.0"
+  s.add_dependency "blacklight", ">= 5.14.0"
   s.add_dependency "cql-ruby", ">=0.8.1"
-  
-  
+
+
   s.add_development_dependency "sqlite3"
   s.add_development_dependency "rspec-rails", "~> 2.6"
   s.add_development_dependency "nokogiri"
   s.add_development_dependency "engine_cart"
-  
+
 
 end
-

--- a/lib/blacklight_cql.rb
+++ b/lib/blacklight_cql.rb
@@ -24,7 +24,7 @@ mattr_accessor :cql_search_field_key
   # Escapes value for Solr LocalParam. Will wrap in
   # quotes only if needed (if not needed, and the value
   # turns out to have been a $param, then quotes will mess
-  # things up!), and escapes value inside quotes. 
+  # things up!), and escapes value inside quotes.
   def self.solr_param_quote(val)
     unless val =~ /^[a-zA-Z$_\-\^]+$/
       val = "'" + escape_quotes(val) + "'"
@@ -48,12 +48,12 @@ mattr_accessor :cql_search_field_key
   #
   # to configure for BlacklightCql
   def self.configure_controller(bl_controller_class)
-    bl_controller_class.blacklight_config.configure do |config|
+    bl_controller_class.config.configure do |config|
       hash = BlacklightCql::SolrHelperExtension.pseudo_search_field
       config.add_search_field hash[:key], hash
     end
 
     bl_controller_class.send(:helper, BlacklightCql::TemplateHelperExtension)
   end
-  
+
 end

--- a/lib/blacklight_cql/controller_extension.rb
+++ b/lib/blacklight_cql/controller_extension.rb
@@ -1,21 +1,21 @@
 # Mix-in for Blacklight CatalogController
 #
-# 1) Adds search_field to the controller representing a CQL search. 
+# 1) Adds search_field to the controller representing a CQL search.
 #    It comes from the SearchBuilderExtension.psuedo_search_field class
 #    variable. It's configured to not show up ordinarily in the search type
-#    select menu, or the advanced search choices either. 
+#    select menu, or the advanced search choices either.
 #
 # 2) Over-rides the default blacklight search_fields methods so that
 #    when CQL search has been triggered, it'll be reflected in the
 #    on-screen search select menu for search type, so the context
-#    makes sense. 
+#    makes sense.
 #
 module BlacklightCql::ControllerExtension
   extend ActiveSupport::Concern
 
 
-  included do 
-    self.blacklight_config.configure do |config|
+  included do
+    self.config.configure do |config|
       hash = BlacklightCql::SearchBuilderExtension.pseudo_search_field
       config.add_search_field hash[:key], hash
     end
@@ -25,17 +25,17 @@ module BlacklightCql::ControllerExtension
 
   module Helpers
     # Make sure the CQL pseudo-search_field is included in the 'select'
-    # when we're displaying a CQL search, so the select makes sense. 
+    # when we're displaying a CQL search, so the select makes sense.
     def search_fields
       field = BlacklightCql::SearchBuilderExtension.pseudo_search_field
-      
+
       if params[:q].blank? || params[:search_field] != field[:key]
         super
-      else      
+      else
         super.clone.push([field[:label], field[:key]]).uniq
       end
     end
   end
-  
-  
+
+
 end

--- a/lib/blacklight_cql/explain_behavior.rb
+++ b/lib/blacklight_cql/explain_behavior.rb
@@ -2,13 +2,13 @@ module BlacklightCql
 
   # Provides an #explain action method which can be mixed into
   # a Blacklight CatalogController type controller, to provide an
-  # explain response. 
+  # explain response.
   module ExplainBehavior
     def cql_explain
        @luke_response = HashWithIndifferentAccess.new(blacklight_solr.get('admin/luke'))
-       @config = blacklight_config
-       
+       @config = config
+
        render "blacklight_cql/explain.xml.builder", :content_type => "application/xml", :layout => false
     end
-  end  
+  end
 end

--- a/lib/blacklight_cql/search_builder_extension.rb
+++ b/lib/blacklight_cql/search_builder_extension.rb
@@ -3,16 +3,16 @@
 # => Adds logic for handling CQL queries, and adds it to the default_processor_chain
 #
 # If you are still using CatalogController#search_params_logic, you will need to add
-# :cql_to_solr_search_params to it. 
+# :cql_to_solr_search_params to it.
 module BlacklightCql::SearchBuilderExtension
     extend ActiveSupport::Concern
-  
+
     mattr_accessor :pseudo_search_field
     # :advanced_parse_q => false, tells the AdvancedSearchPlugin not to try
-    # to parse this for parens and booleans, we're taking care of it! 
-    self.pseudo_search_field = {:key => "cql", :label => "External Search (CQL)", :include_in_simple_select => false, 
+    # to parse this for parens and booleans, we're taking care of it!
+    self.pseudo_search_field = {:key => "cql", :label => "External Search (CQL)", :include_in_simple_select => false,
       # Different versions of advanced search may use different keys here (?)
-      :advanced_parse_q => false, 
+      :advanced_parse_q => false,
       :advanced_parse => false,
       :include_in_advanced_search => false
     }
@@ -20,7 +20,7 @@ module BlacklightCql::SearchBuilderExtension
     included do
       self.default_processor_chain << :cql_to_solr_search_params
     end
-    
+
     # Over-ride solr_search_params to do special CQL-to-complex-solr-query
     # processing iff the "search_field" is our pseudo-search-field indicating
     # a CQL query.
@@ -29,10 +29,10 @@ module BlacklightCql::SearchBuilderExtension
       if blacklight_params["search_field"] == self.pseudo_search_field[:key] && ! blacklight_params["q"].blank?
         parser = CqlRuby::CqlParser.new
 
-        solr_params[:q] = "{!lucene} " + parser.parse( blacklight_params["q"] ).to_bl_solr(self.blacklight_config)     
+        solr_params[:q] = "{!lucene} " + parser.parse( blacklight_params["q"] ).to_bl_solr(self.blacklight_config)
       end
       return solr_params
     end
-    
-    
+
+
 end


### PR DESCRIPTION
These are the minimal changes to get this working in Blacklight 7. The `gemspec` has been modified so that
the version range is relaxed and references to `blacklight_config` have been replaced with `config`. 